### PR TITLE
Process queuing

### DIFF
--- a/configs/MuTILsWSIRunConfigs.py
+++ b/configs/MuTILsWSIRunConfigs.py
@@ -1,9 +1,13 @@
 import os
 from os.path import join as opj
 import yaml
+import numpy as np
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
 
-from MuTILs_Panoptic.utils.MiscRegionUtils import get_configured_logger, load_region_configs
-from MuTILs_Panoptic.utils.GeneralUtils import splitlist
+from MuTILs_Panoptic.utils.TorchUtils import transform_dlinput
+from MuTILs_Panoptic.utils.MiscRegionUtils import get_configured_logger
+import MuTILs_Panoptic.configs.panoptic_model_configs as model_configs
 
 configuration_file = os.path.abspath(__file__).split('.')[0] + '.yaml'
 
@@ -51,49 +55,19 @@ class ConfigParser:
         except yaml.YAMLError as ye:
             raise ye
 
-    @staticmethod
-    def check_config(config_dictionary: dict) -> None:
-        """Check if the configuration values are set in the config file properly.
-
-        Args:
-            config_dictionary (dict): Configuration dictionary
-
-        Raises:
-            KeyError: If any of the required configuration values are not set in the config file.
-        """
-        required_keys = ['model_configs', 
-                         'slides_path', 'base_savedir', 'model_paths',
-                         'save_wsi_mask', 'save_annotations','save_nuclei_meta', 'save_nuclei_props', 
-                         'roi_side_hres', 'discard_edge_hres', 'roi_clust_mpp',
-                         'topk_rois', 'vlres_scorer_kws', 'roi_kmeans_kvp', 'topk_rois_sampling_mode',
-                         'independent_tile_assignment',
-                         'cnorm', 'cnorm_kwargs', 'maskout_regions_for_cnorm', 'ntta', 'dltransforms',
-                         'valid_extensions',
-                         'filter_stromal_whitespace', 'min_tumor_for_saliency',
-                         'max_salient_stroma_distance', 'topk_salient_rois',
-                         'no_watershed_nucleus_classes', 
-                         'min_nucl_size', 'max_nucl_size', 'nprops_kwargs',
-                         'N_SUBSETS', 'N_CPUs', '_debug'
-        ]
-        for key in required_keys:
-            if key not in config_dictionary:
-                raise KeyError(f'{key} not set in config file')
-
 class RunConfigs:
 
-    @classmethod
-    def initialize(cls):
+    def __init__(self):
         """Initialize the configuration parameters for the pipeline.
         """
         # Load configuration parameters from the YAML file
-        cls.RUN_KWARGS = ConfigParser.parse_config(configuration_file)
-        ConfigParser.check_config(cls.RUN_KWARGS)
+        RUN_KWARGS = ConfigParser.parse_config(configuration_file)
 
         # Set further configuration parameters
-        cls.RUN_KWARGS['logger'] = Logger.set_up_logger(cls.RUN_KWARGS['base_savedir'])
-        cls.RUN_KWARGS['model_configs'] = load_region_configs(cls.RUN_KWARGS['model_configs'], warn=False)
+        RUN_KWARGS['logger'] = Logger.set_up_logger(RUN_KWARGS['base_savedir'])
+        RUN_KWARGS['slide_names'] = self.get_slide_names(RUN_KWARGS)
 
-        cls.SLIDENAMES = cls.get_slide_names(cls.RUN_KWARGS)
+        self.config = Config(**RUN_KWARGS)
 
     @staticmethod
     def get_slide_names(run_kwargs: dict) -> list:
@@ -108,4 +82,177 @@ class RunConfigs:
         all_slidenames = os.listdir(run_kwargs['slides_path'])
         all_slidenames.sort()
 
-        return splitlist(all_slidenames, len(all_slidenames) // run_kwargs['N_SUBSETS'])
+        return all_slidenames
+
+    def get_config(self):
+        """Get the configuration object.
+
+        Returns:
+            Config: The configuration object.
+        """
+        return self.config
+
+
+def default_model_paths() -> Dict[str, str]:
+    return {
+        "mutils_06022021-fold1": "/home/models/fold_1/mutils_06022021_fold1.pt",
+        "mutils_06022021-fold2": "/home/models/fold_2/mutils_06022021_fold2.pt",
+        "mutils_06022021-fold3": "/home/models/fold_3/mutils_06022021_fold3.pt",
+        "mutils_06022021-fold4": "/home/models/fold_4/mutils_06022021_fold4.pt",
+        "mutils_06022021-fold5": "/home/models/fold_5/mutils_06022021_fold5.pt"
+    }
+
+def default_cnorm_kwargs() -> Dict[str, Any]:
+    return {
+        'W_target': np.array([
+            [0.5807549, 0.08314027, 0.08213795],
+            [0.71681094, 0.90081588, 0.41999816],
+            [0.38588316, 0.42616716, -0.90380025]
+        ]),
+        'stain_unmixing_routine_params': {
+            'stains': ['hematoxylin', 'eosin'],
+            'stain_unmixing_method': 'macenko_pca',
+        },
+    }
+
+def default_nprops_kwargs() -> Dict[str, Any]:
+    return {
+        'fsd_bnd_pts': 128,
+        'fsd_freq_bins': 6,
+        'cyto_width': 8,
+        'num_glcm_levels': 32,
+        'morphometry_features_flag': True,
+        'fsd_features_flag': True,
+        'intensity_features_flag': True,
+        'gradient_features_flag': True,
+        'haralick_features_flag':True
+    }
+
+def default_roi_kmeans_kvp() -> Dict[str, Any]:
+    return {
+            'n_segments': 128,
+            'compactness': 10,
+            'threshold': 9
+    }
+
+@dataclass
+class Config:
+    """Configuration class for the MuTILsWSIRunner."""
+    slides_path: str = '/home/input'
+    base_savedir: str = '/home/output'
+    model_paths: Dict[str, str] = field(default_factory=default_model_paths)
+    monitor: str = ''
+
+    save_wsi_mask: bool = False
+    save_annotations: bool = False
+    save_nuclei_meta: bool = True
+    save_nuclei_props: bool = True
+
+    roi_side_hres: int = 1024
+    discard_edge_hres: int = 0
+    roi_clust_mpp: float = 20.0
+
+    topk_rois: Optional[int] = None
+    topk_salient_rois: Optional[int] = None
+
+    vlres_scorer_kws: Dict[str, Any] = None
+    roi_kmeans_kvp: Optional[Dict[str, Any]] = field(default_factory=default_roi_kmeans_kvp)
+
+    topk_rois_sampling_mode: str = "stratified"
+    independent_tile_assignment: bool = True
+
+    cnorm: bool = True
+    cnorm_kwargs: Dict[str, Any] = field(default_factory=default_cnorm_kwargs)
+    maskout_regions_for_cnorm: List[str] = field(default_factory=lambda: ['BLOOD', 'WHITE', 'EXCLUDE'])
+
+    ntta: int = 0
+    dltransforms: Optional[List[Dict[str, Any]]] = None
+
+    valid_extensions: List[str] = field(default_factory=lambda: ['.svs', '.tif', '.tiff', '.ndpi', '.mrxs', '.scn'])
+
+    filter_stromal_whitespace: bool = False
+    min_tumor_for_saliency: int = 4
+    max_salient_stroma_distance: int = 64
+
+    no_watershed_nucleus_classes: List[str] = field(default_factory=lambda: ['StromalCellNOS', 'ActiveStromalCellNOS'])
+
+    min_nucl_size: int = 5
+    max_nucl_size: int = 90
+    nprops_kwargs: Optional[Dict[str, Any]] = field(default_factory=default_nprops_kwargs)
+
+    mtp: Any = field(default_factory=lambda: model_configs.MuTILsParams)
+    rcc: Any = field(default_factory=lambda: model_configs.RegionCellCombination)
+    rcd: Any = field(default_factory=lambda: model_configs.RegionCellCombination.REGION_CODES)
+    ncd: Any = field(default_factory=lambda: model_configs.RegionCellCombination.NUCLEUS_CODES)
+    no_watershed_lbls: Dict = field(init=False)
+    maskout_region_codes: List = field(init=False)
+
+    hres_mpp: float = field(init=False)
+    lres_mpp: float = field(init=False)
+    vlres_mpp: float = field(init=False)
+    h2l: float = field(init=False)
+    h2vl: float = field(init=False)
+    roi_side_lres: int = field(init=False)
+    roi_side_vlres: int = field(init=False)
+    n_edge_pixels_discarded: float = field(init=False)
+
+    N_CPUs: int = 1
+    _debug: bool = False
+
+    logger: Optional[Any] = field(default=None)
+    slide_names: List[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        os.makedirs(self.base_savedir, exist_ok=True)
+        self.base_savedir = opj(self.base_savedir, 'perSlideResults')
+
+        assert all(os.path.isfile(j) for j in self.model_paths.values()), \
+            "Some of the models weight files do not exist!"
+
+        assert self.topk_rois_sampling_mode in ("stratified", "weighted", "sorted")
+
+        if self.topk_rois is not None:
+            assert self.topk_salient_rois <= self.topk_rois, (
+                "The no. of salient ROIs used for final TILs scoring must be "
+                "less than the total no. of rois that we do inference on!"
+            )
+
+        self.no_watershed_lbls = {
+            self.ncd[cls] for cls in self.no_watershed_nucleus_classes}
+
+        self.maskout_region_codes = [
+            self.rcd[reg] for reg in self.maskout_regions_for_cnorm]
+
+        self.hres_mpp = self.mtp.model_params['hpf_mpp']
+        self.lres_mpp = self.mtp.model_params['roi_mpp']
+        self.vlres_mpp = 2 * self.lres_mpp
+        self.h2l = self.hres_mpp / self.lres_mpp
+        self.h2vl = self.hres_mpp / self.vlres_mpp
+        self.roi_side_lres = int(self.h2l * self.roi_side_hres)
+        self.roi_side_vlres = int(self.h2vl * self.roi_side_hres)
+        self.n_edge_pixels_discarded = 4 * self.discard_edge_hres * (
+            self.roi_side_hres - self.discard_edge_hres)
+
+        self.mtp.model_params.update({
+            'training': False,
+            'roi_side': self.roi_side_lres,
+            'hpf_side': self.roi_side_hres,  # predict all nuclei in roi
+            'topk_hpf': 1,
+        })
+
+        self.vlres_scorer_kws = self.vlres_scorer_kws or {
+            'check_tissue': True,
+            'tissue_percent': 50,
+            'pixel_overlap': int(2 * self.discard_edge_hres * self.h2vl),
+        }
+
+        self.dltransforms = self.dltransforms or transform_dlinput(
+            tlist=['augment_stain'],
+            make_tensor=False,
+            augment_stain_sigma1=0.75,
+            augment_stain_sigma2=0.75,
+        )
+
+        if self._debug:
+            self.monitor = '[DEBUG]'
+

--- a/configs/MuTILsWSIRunConfigs.py
+++ b/configs/MuTILsWSIRunConfigs.py
@@ -9,13 +9,14 @@ from MuTILs_Panoptic.utils.TorchUtils import transform_dlinput
 from MuTILs_Panoptic.utils.MiscRegionUtils import get_configured_logger
 import MuTILs_Panoptic.configs.panoptic_model_configs as model_configs
 
-configuration_file = os.path.abspath(__file__).split('.')[0] + '.yaml'
+configuration_file = os.path.abspath(__file__).split(".")[0] + ".yaml"
+
 
 class Logger:
 
     @staticmethod
     def set_up_logger(log_dir: str) -> object:
-        """ Set up the logger for the project.
+        """Set up the logger for the project.
 
         Args:
             log_dir (str): Path to the directory where the logs will be saved.
@@ -23,13 +24,16 @@ class Logger:
         Returns:
             object: The logger object."""
         if not os.path.exists(log_dir):
-            raise FileNotFoundError('Folder does not exist')
+            raise FileNotFoundError("Folder does not exist")
 
-        LOGDIR = opj(log_dir, 'LOGS')
+        LOGDIR = opj(log_dir, "LOGS")
         os.makedirs(LOGDIR, exist_ok=True)
 
-        logger = get_configured_logger(logdir=LOGDIR, prefix='MuTILsWSIRunner', tofile=True)
+        logger = get_configured_logger(
+            logdir=LOGDIR, prefix="MuTILsWSIRunner", tofile=True
+        )
         return logger
+
 
 class ConfigParser:
 
@@ -48,24 +52,24 @@ class ConfigParser:
             yaml.YAMLError: If there is an error parsing the YAML file.
         """
         try:
-            with open(config_file, 'r') as ymlfile:
+            with open(config_file, "r") as ymlfile:
                 return yaml.load(ymlfile, Loader=yaml.FullLoader)
         except FileNotFoundError as fnfe:
             raise fnfe
         except yaml.YAMLError as ye:
             raise ye
 
+
 class RunConfigs:
 
     def __init__(self):
-        """Initialize the configuration parameters for the pipeline.
-        """
+        """Initialize the configuration parameters for the pipeline."""
         # Load configuration parameters from the YAML file
         RUN_KWARGS = ConfigParser.parse_config(configuration_file)
 
         # Set further configuration parameters
-        RUN_KWARGS['logger'] = Logger.set_up_logger(RUN_KWARGS['base_savedir'])
-        RUN_KWARGS['slide_names'] = self.get_slide_names(RUN_KWARGS)
+        RUN_KWARGS["logger"] = Logger.set_up_logger(RUN_KWARGS["base_savedir"])
+        RUN_KWARGS["slide_names"] = self.get_slide_names(RUN_KWARGS)
 
         self.config = Config(**RUN_KWARGS)
 
@@ -79,7 +83,7 @@ class RunConfigs:
         Returns:
             list: List of slide names.
         """
-        all_slidenames = os.listdir(run_kwargs['slides_path'])
+        all_slidenames = os.listdir(run_kwargs["slides_path"])
         all_slidenames.sort()
 
         return all_slidenames
@@ -99,49 +103,52 @@ def default_model_paths() -> Dict[str, str]:
         "mutils_06022021-fold2": "/home/models/fold_2/mutils_06022021_fold2.pt",
         "mutils_06022021-fold3": "/home/models/fold_3/mutils_06022021_fold3.pt",
         "mutils_06022021-fold4": "/home/models/fold_4/mutils_06022021_fold4.pt",
-        "mutils_06022021-fold5": "/home/models/fold_5/mutils_06022021_fold5.pt"
+        "mutils_06022021-fold5": "/home/models/fold_5/mutils_06022021_fold5.pt",
     }
+
 
 def default_cnorm_kwargs() -> Dict[str, Any]:
     return {
-        'W_target': np.array([
-            [0.5807549, 0.08314027, 0.08213795],
-            [0.71681094, 0.90081588, 0.41999816],
-            [0.38588316, 0.42616716, -0.90380025]
-        ]),
-        'stain_unmixing_routine_params': {
-            'stains': ['hematoxylin', 'eosin'],
-            'stain_unmixing_method': 'macenko_pca',
+        "W_target": np.array(
+            [
+                [0.5807549, 0.08314027, 0.08213795],
+                [0.71681094, 0.90081588, 0.41999816],
+                [0.38588316, 0.42616716, -0.90380025],
+            ]
+        ),
+        "stain_unmixing_routine_params": {
+            "stains": ["hematoxylin", "eosin"],
+            "stain_unmixing_method": "macenko_pca",
         },
     }
 
+
 def default_nprops_kwargs() -> Dict[str, Any]:
     return {
-        'fsd_bnd_pts': 128,
-        'fsd_freq_bins': 6,
-        'cyto_width': 8,
-        'num_glcm_levels': 32,
-        'morphometry_features_flag': True,
-        'fsd_features_flag': True,
-        'intensity_features_flag': True,
-        'gradient_features_flag': True,
-        'haralick_features_flag':True
+        "fsd_bnd_pts": 128,
+        "fsd_freq_bins": 6,
+        "cyto_width": 8,
+        "num_glcm_levels": 32,
+        "morphometry_features_flag": True,
+        "fsd_features_flag": True,
+        "intensity_features_flag": True,
+        "gradient_features_flag": True,
+        "haralick_features_flag": True,
     }
 
+
 def default_roi_kmeans_kvp() -> Dict[str, Any]:
-    return {
-            'n_segments': 128,
-            'compactness': 10,
-            'threshold': 9
-    }
+    return {"n_segments": 128, "compactness": 10, "threshold": 9}
+
 
 @dataclass
 class Config:
     """Configuration class for the MuTILsWSIRunner."""
-    slides_path: str = '/home/input'
-    base_savedir: str = '/home/output'
+
+    slides_path: str = "/home/input"
+    base_savedir: str = "/home/output"
     model_paths: Dict[str, str] = field(default_factory=default_model_paths)
-    monitor: str = ''
+    monitor: str = ""
 
     save_wsi_mask: bool = False
     save_annotations: bool = False
@@ -156,34 +163,48 @@ class Config:
     topk_salient_rois: Optional[int] = None
 
     vlres_scorer_kws: Dict[str, Any] = None
-    roi_kmeans_kvp: Optional[Dict[str, Any]] = field(default_factory=default_roi_kmeans_kvp)
+    roi_kmeans_kvp: Optional[Dict[str, Any]] = field(
+        default_factory=default_roi_kmeans_kvp
+    )
 
     topk_rois_sampling_mode: str = "stratified"
     independent_tile_assignment: bool = True
 
     cnorm: bool = True
     cnorm_kwargs: Dict[str, Any] = field(default_factory=default_cnorm_kwargs)
-    maskout_regions_for_cnorm: List[str] = field(default_factory=lambda: ['BLOOD', 'WHITE', 'EXCLUDE'])
+    maskout_regions_for_cnorm: List[str] = field(
+        default_factory=lambda: ["BLOOD", "WHITE", "EXCLUDE"]
+    )
 
     ntta: int = 0
     dltransforms: Optional[List[Dict[str, Any]]] = None
 
-    valid_extensions: List[str] = field(default_factory=lambda: ['.svs', '.tif', '.tiff', '.ndpi', '.mrxs', '.scn'])
+    valid_extensions: List[str] = field(
+        default_factory=lambda: [".svs", ".tif", ".tiff", ".ndpi", ".mrxs", ".scn"]
+    )
 
     filter_stromal_whitespace: bool = False
     min_tumor_for_saliency: int = 4
     max_salient_stroma_distance: int = 64
 
-    no_watershed_nucleus_classes: List[str] = field(default_factory=lambda: ['StromalCellNOS', 'ActiveStromalCellNOS'])
+    no_watershed_nucleus_classes: List[str] = field(
+        default_factory=lambda: ["StromalCellNOS", "ActiveStromalCellNOS"]
+    )
 
     min_nucl_size: int = 5
     max_nucl_size: int = 90
-    nprops_kwargs: Optional[Dict[str, Any]] = field(default_factory=default_nprops_kwargs)
+    nprops_kwargs: Optional[Dict[str, Any]] = field(
+        default_factory=default_nprops_kwargs
+    )
 
     mtp: Any = field(default_factory=lambda: model_configs.MuTILsParams)
     rcc: Any = field(default_factory=lambda: model_configs.RegionCellCombination)
-    rcd: Any = field(default_factory=lambda: model_configs.RegionCellCombination.REGION_CODES)
-    ncd: Any = field(default_factory=lambda: model_configs.RegionCellCombination.NUCLEUS_CODES)
+    rcd: Any = field(
+        default_factory=lambda: model_configs.RegionCellCombination.REGION_CODES
+    )
+    ncd: Any = field(
+        default_factory=lambda: model_configs.RegionCellCombination.NUCLEUS_CODES
+    )
     no_watershed_lbls: Dict = field(init=False)
     maskout_region_codes: List = field(init=False)
 
@@ -196,7 +217,8 @@ class Config:
     roi_side_vlres: int = field(init=False)
     n_edge_pixels_discarded: float = field(init=False)
 
-    N_CPUs: int = 1
+    N_preprocesses: int = 1
+    N_postprocesses: int = 1
     _debug: bool = False
 
     logger: Optional[Any] = field(default=None)
@@ -204,10 +226,11 @@ class Config:
 
     def __post_init__(self):
         os.makedirs(self.base_savedir, exist_ok=True)
-        self.base_savedir = opj(self.base_savedir, 'perSlideResults')
+        self.base_savedir = opj(self.base_savedir, "perSlideResults")
 
-        assert all(os.path.isfile(j) for j in self.model_paths.values()), \
-            "Some of the models weight files do not exist!"
+        assert all(
+            os.path.isfile(j) for j in self.model_paths.values()
+        ), "Some of the models weight files do not exist!"
 
         assert self.topk_rois_sampling_mode in ("stratified", "weighted", "sorted")
 
@@ -218,41 +241,45 @@ class Config:
             )
 
         self.no_watershed_lbls = {
-            self.ncd[cls] for cls in self.no_watershed_nucleus_classes}
+            self.ncd[cls] for cls in self.no_watershed_nucleus_classes
+        }
 
         self.maskout_region_codes = [
-            self.rcd[reg] for reg in self.maskout_regions_for_cnorm]
+            self.rcd[reg] for reg in self.maskout_regions_for_cnorm
+        ]
 
-        self.hres_mpp = self.mtp.model_params['hpf_mpp']
-        self.lres_mpp = self.mtp.model_params['roi_mpp']
+        self.hres_mpp = self.mtp.model_params["hpf_mpp"]
+        self.lres_mpp = self.mtp.model_params["roi_mpp"]
         self.vlres_mpp = 2 * self.lres_mpp
         self.h2l = self.hres_mpp / self.lres_mpp
         self.h2vl = self.hres_mpp / self.vlres_mpp
         self.roi_side_lres = int(self.h2l * self.roi_side_hres)
         self.roi_side_vlres = int(self.h2vl * self.roi_side_hres)
-        self.n_edge_pixels_discarded = 4 * self.discard_edge_hres * (
-            self.roi_side_hres - self.discard_edge_hres)
+        self.n_edge_pixels_discarded = (
+            4 * self.discard_edge_hres * (self.roi_side_hres - self.discard_edge_hres)
+        )
 
-        self.mtp.model_params.update({
-            'training': False,
-            'roi_side': self.roi_side_lres,
-            'hpf_side': self.roi_side_hres,  # predict all nuclei in roi
-            'topk_hpf': 1,
-        })
+        self.mtp.model_params.update(
+            {
+                "training": False,
+                "roi_side": self.roi_side_lres,
+                "hpf_side": self.roi_side_hres,  # predict all nuclei in roi
+                "topk_hpf": 1,
+            }
+        )
 
         self.vlres_scorer_kws = self.vlres_scorer_kws or {
-            'check_tissue': True,
-            'tissue_percent': 50,
-            'pixel_overlap': int(2 * self.discard_edge_hres * self.h2vl),
+            "check_tissue": True,
+            "tissue_percent": 50,
+            "pixel_overlap": int(2 * self.discard_edge_hres * self.h2vl),
         }
 
         self.dltransforms = self.dltransforms or transform_dlinput(
-            tlist=['augment_stain'],
+            tlist=["augment_stain"],
             make_tensor=False,
             augment_stain_sigma1=0.75,
             augment_stain_sigma2=0.75,
         )
 
         if self._debug:
-            self.monitor = '[DEBUG]'
-
+            self.monitor = "[DEBUG]"

--- a/configs/MuTILsWSIRunConfigs.yaml
+++ b/configs/MuTILsWSIRunConfigs.yaml
@@ -23,5 +23,6 @@ save_nuclei_props: True
 ## ----------------------------------------------------------------
 # Run configurations
 ## ----------------------------------------------------------------
-N_CPUs: 15
-_debug: True
+N_preprocesses: 10
+N_postprocesses: 40
+_debug: False

--- a/configs/MuTILsWSIRunConfigs.yaml
+++ b/configs/MuTILsWSIRunConfigs.yaml
@@ -1,9 +1,4 @@
 ## ----------------------------------------------------------------
-# The configuration file for running the MuTILs pipeline on WSI data
-## ----------------------------------------------------------------
-model_configs: 'panoptic_model_configs.py'
-
-## ----------------------------------------------------------------
 # Input paths - fixed
 # mount the container to these paths in the docker compose yaml file
 ## ----------------------------------------------------------------
@@ -20,65 +15,13 @@ model_paths:
 ## ----------------------------------------------------------------
 # Output saving options
 ## ----------------------------------------------------------------
-save_wsi_mask: True
+save_wsi_mask: False
 save_annotations: False
 save_nuclei_meta: True
 save_nuclei_props: True
 
 ## ----------------------------------------------------------------
-# Inference configurations
-## ----------------------------------------------------------------
-# roi size and scoring
-roi_side_hres: 1024
-discard_edge_hres: 0
-roi_clust_mpp: 20.0  # 0.5x
-topk_rois: null
-vlres_scorer_kws: null                  # null or custom dict of:
-#   check_tissue: True
-#   tissue_percent: 25
-#   pixel_overlap: 0
-roi_kmeans_kvp: null                    # null or custom dict of:
-#   n_segments: 128
-#   compactness: 10
-#   threshold: 9
-topk_rois_sampling_mode: "stratified"   # or "weighted"
-independent_tile_assignment: True
-# color normalization & augmentation
-cnorm: True
-cnorm_kwargs: null
-maskout_regions_for_cnorm: null         # null or list of:
-  # - BLOOD 
-  # - WHITE
-  # - EXCLUDE
-ntta: 0
-dltransforms: null
-# misc params
-valid_extensions: null
-# intra-tumoral stroma (saliency)
-filter_stromal_whitespace: False
-min_tumor_for_saliency: 4
-max_salient_stroma_distance: 64
-topk_salient_rois: 64
-# parsing nuclei from inference
-no_watershed_nucleus_classes: null    # null or list of:
-  # - StromalCellNOS
-  # - ActiveStromalCellNOS
-min_nucl_size: 5
-max_nucl_size: 90
-nprops_kwargs: null                   # null or custom dict of:
-  # fsd_bnd_pts: 128
-  # fsd_freq_bins: 6 
-  # cyto_width: 8
-  # num_glcm_levels: 32
-  # morphometry_features_flag: True
-  # fsd_features_flag: True
-  # intensity_features_flag: True
-  # gradient_features_flag: True
-  # haralick_features_flag: True
-
-## ----------------------------------------------------------------
 # Run configurations
 ## ----------------------------------------------------------------
-N_SUBSETS: 1
-N_CPUs: 10
+N_CPUs: 15
 _debug: True

--- a/mutils_panoptic/MuTILsInference.py
+++ b/mutils_panoptic/MuTILsInference.py
@@ -270,15 +270,23 @@ class ROIInferenceProcessor:
 
     def inference(self, roi: ROI):
 
-        highres_rgb = torch.as_tensor(roi.batch.highres_rgb, dtype=torch.float32)
-        lowres_rgb = torch.as_tensor(roi.batch.lowres_rgb, dtype=torch.float32)
-        lowres_ignore = torch.as_tensor(roi.batch.lowres_ignore, dtype=torch.float32)
+        device = f"cuda:{self.gpu_id}" if torch.cuda.is_available() else "cpu"
+
+        highres_rgb = torch.as_tensor(
+            roi.batch.highres_rgb, dtype=torch.float32, device=device
+        )
+        lowres_rgb = torch.as_tensor(
+            roi.batch.lowres_rgb, dtype=torch.float32, device=device
+        )
+        lowres_ignore = torch.as_tensor(
+            roi.batch.lowres_ignore, dtype=torch.float32, device=device
+        )
 
         batchdata = [
             {
-                "highres_rgb": highres_rgb.to(f"cuda:{self.gpu_id}"),
-                "lowres_rgb": lowres_rgb.to(f"cuda:{self.gpu_id}"),
-                "lowres_ignore": lowres_ignore.to(f"cuda:{self.gpu_id}"),
+                "highres_rgb": highres_rgb,
+                "lowres_rgb": lowres_rgb,
+                "lowres_ignore": lowres_ignore,
             }
         ]
 

--- a/mutils_panoptic/MuTILsInference.py
+++ b/mutils_panoptic/MuTILsInference.py
@@ -3,7 +3,6 @@ import numpy as np
 import torch
 import matplotlib.pylab as plt
 import ast
-import sys
 from os.path import join as opj
 from PIL import Image
 from imageio import imwrite
@@ -12,225 +11,186 @@ from pandas import DataFrame, concat
 from skimage.morphology import binary_dilation
 from dataclasses import dataclass
 from skimage.measure import regionprops
+import multiprocessing as mp
 
 # histolab
 from histolab.util import np_to_pil
 from histolab.tile import Tile
 
 # histomicstk
-from histomicstk.preprocessing.color_normalization import deconvolution_based_normalization
+from histomicstk.preprocessing.color_normalization import (
+    deconvolution_based_normalization,
+)
 from histomicstk.preprocessing.color_deconvolution import color_deconvolution_routine
 from histomicstk.features.compute_nuclei_features import compute_nuclei_features
 
 # mutils
-from MuTILs_Panoptic.utils.RegionPlottingUtils import get_visualization_ready_combined_mask as gvcm
-from MuTILs_Panoptic.utils.GeneralUtils import unique_nonzero, CollectErrors, save_json, _divnonan
+from MuTILs_Panoptic.utils.RegionPlottingUtils import (
+    get_visualization_ready_combined_mask as gvcm,
+)
+from MuTILs_Panoptic.utils.GeneralUtils import (
+    unique_nonzero,
+    CollectErrors,
+    save_json,
+    _divnonan,
+    move_to_cpu_recursive,
+)
 from MuTILs_Panoptic.utils.CythonUtils import cy_argwhere
 from MuTILs_Panoptic.utils.MiscRegionUtils import (
-    pil2tensor, logits2preds, summarize_nuclei_mask, get_configured_logger,
-    get_objects_from_binmask, get_region_within_x_pixels, summarize_region_mask
+    logits2preds,
+    summarize_nuclei_mask,
+    get_objects_from_binmask,
+    get_region_within_x_pixels,
+    summarize_region_mask,
+    get_configured_logger,
 )
-from MuTILs_Panoptic.configs.panoptic_model_configs import (
-    RegionCellCombination, MuTILsParams, VisConfigs
-)
+import MuTILs_Panoptic.configs.panoptic_model_configs as model_configs
 
 collect_errors = CollectErrors()
 
+
 @dataclass
-class RoiProcessorConfig:
-    _debug: bool
-    _sldname: str
-    models: dict
-    _top_rois: any
-    _slide: any
-    hres_mpp: float
-    roi_side_hres: int
-    roi_side_lres: int
-    cnorm: bool
-    cnorm_kwargs: dict
-    ntta: int
-    discard_edge_hres: int
-    filter_stromal_whitespace: bool
-    no_watershed_nucleus_classes: list
-    maskout_regions_for_cnorm: list
-    min_nucl_size: int
-    max_nucl_size: int
-    max_salient_stroma_distance: float
-    min_tumor_for_saliency: float
-    nprops_kwargs: dict
-    _savedir: str
-    save_wsi_mask: bool
-    save_nuclei_meta: bool
-    save_nuclei_props: bool
-    save_annotations: bool
+class BatchData:
+    """Dataclass of a single batch. It is the input of the model. It stores:
+    - highres_rgb: np.ndarray - the high resolution RGB image
+    - lowres_rgb: np.ndarray - the low resolution RGB image
+    - lowres_ignore: np.ndarray - the low resolution ignore mask
+    """
 
-class RoiProcessor:
-    _logger = None
-    def __init__(self, config: RoiProcessorConfig):
-        self.__dict__.update(config.__dict__)
+    highres_rgb: np.ndarray = np.array([], dtype=np.uint32)
+    lowres_rgb: np.ndarray = np.array([], dtype=np.uint32)
+    lowres_ignore: np.ndarray = np.array([], dtype=np.uint32)
 
-        self.mtp = MuTILsParams
-        self.rcc = RegionCellCombination
-        self.rcd = RegionCellCombination.REGION_CODES
-        self.ncd = RegionCellCombination.NUCLEUS_CODES
-        self.VisConfigs = VisConfigs
-        self.no_watershed_lbls = {
-            self.ncd[cls] for cls in self.no_watershed_nucleus_classes}
-        self.maskout_region_codes = [
-            self.rcd[reg] for reg in self.maskout_regions_for_cnorm]
-        self.n_edge_pixels_discarded = 4 * self.discard_edge_hres * (
-            self.roi_side_hres - self.discard_edge_hres)
+    def to_cpu(self):
+        self.highres_rgb = move_to_cpu_recursive(self.highres_rgb)
+        self.lowres_rgb = move_to_cpu_recursive(self.lowres_rgb)
+        self.lowres_ignore = move_to_cpu_recursive(self.lowres_ignore)
 
-        self.preprocessor = RoiPreProcessor(self)
-        self.inferenceprocessor = RoiInferenceProcessor(self)
-        self.postprocessor = RoiPostProcessor(self)
 
-    def run(self, rois: list, chunk_id: int=None) -> None:
-        """Run model over multiple rois.
+@dataclass
+class ROI:
+    """Dataclass of a single ROI. It stores:
+    - number: int - the number of the ROI i.e. its index in the slide
+    - name: str - the name of the ROI
+    - model: str - the model assigned to the ROI to process it
+    - batch: BatchData - the batch data of the ROI holding the RGB images
+    - hres_ignore: np.ndarray - the ignore mask for the high resolution image
+    - img: Image.Image - the RGB image of the ROI
+    """
 
-        Parameters:
-        ----------
-        rois: list
-            List of a chunk of ROIs to process. Each element is a tuple
-            containing the ROI id and the model name to use.
-        chunk_id: int
-            Chunk id to use for logging.
-        """
-        if chunk_id is not None:
-            self.logger = get_configured_logger(logdir="/home/output/LOGS", prefix=f'MuTILsWSIRunner_chunk{chunk_id}', tofile=True)
-            collect_errors.logger = self.logger
+    number: int
+    coords: list[int]
+    name: str
+    model: str
+    batch: BatchData
+    hres_ignore: np.ndarray
+    img: Image.Image
 
-        for roi in rois:
-            self.run_roi(roi)
+    def to_cpu(self):
+        self.batch.to_cpu()
+        self.hres_ignore = move_to_cpu_recursive(self.hres_ignore)
 
-    @collect_errors()
-    def run_roi(self, roi: tuple) -> None:
-        """Run model over a single roi.
 
-        Parameters:
-        ----------
-        roi: tuple
-            Tuple containing the ROI id and the model name to use.
-        """
-        self._rid = roi[0]
-        self._modelname = roi[1]
-        self._roiname = (
-            f"{self._sldname}_roi-{self._rid}"
-            f"{self._bounds2str(*self._roicoords)}"
+@dataclass
+class InferenceResult:
+    """Dataclass of a single inference result. It stores:
+    - number: int - the number of the ROI i.e. its index in the slide
+    - coords: list[int] - the coordinates of the ROI
+    - name: str - the name of the ROI
+    - model: str - the model assigned to the ROI to process it
+    - batch: BatchData - the batch data of the ROI holding the RGB images
+    - hres_ignore: np.ndarray - the ignore mask for the high resolution image
+    - img: Image.Image - the RGB image of the ROI
+    - result: np.ndarray - the result of the inference
+    """
+
+    number: int
+    coords: list[int]
+    name: str
+    model: str
+    batch: BatchData
+    hres_ignore: np.ndarray
+    img: Image.Image
+    result: np.ndarray
+
+    def to_cpu(self):
+        self.batch.to_cpu()
+        self.hres_ignore = move_to_cpu_recursive(self.hres_ignore)
+        self.result = move_to_cpu_recursive(self.result)
+
+
+class ROIPreProcessor:
+    def __init__(self, inference_queue: mp.Queue, roi_chunk: list, configs: dict):
+        self.inference_queue = inference_queue
+        self.roi_chunk = roi_chunk
+        self._sldname = configs.get("_sldname")
+        self._top_rois = configs.get("_top_rois")
+        self._slide = configs.get("_slide")
+        self.hres_mpp = configs.get("hres_mpp")
+        self.roi_side_hres = configs.get("roi_side_hres")
+        self.roi_side_lres = configs.get("roi_side_lres")
+        self.cnorm = configs.get("cnorm")
+        self.cnorm_kwargs = configs.get("cnorm_kwargs")
+
+    def run(self):
+        """Loop through one chunk."""
+        for single_roi in self.roi_chunk:
+            self.run_roi(single_roi)
+            self.inference_queue.put(self.roi)
+
+    def run_roi(self, single_roi: tuple):
+        """Run the preprocessing for one ROI."""
+        self.roi = ROI(
+            number=single_roi[0],
+            coords=self._get_roi_coords(single_roi[0]),
+            name="",
+            model=single_roi[1],
+            batch=BatchData(),
+            hres_ignore=np.array([]),
+            img=None,
         )
-
-        self.set_device()
-
-        # Get tile
-        try:
-            tile = self.get_tile()
-        except Exception as e:
-            self.logger.error(f"Error getting tile for ROI {self._rid}: {e}")
-            sys.exit(1)
-        # Run preprocessing
-        try:
-            rgb, batch, hres_ignore = self.preprocessor.run(tile)
-        except Exception as e:
-            self.logger.error(f"Error preprocessing ROI {self._rid}: {e}")
-            torch.cuda.empty_cache()
-            sys.exit(1)
-        # Run inference
-        try:
-            inference = self.inferenceprocessor.run(batch)
-        except Exception as e:
-            self.logger.error(f"Error running inference for ROI {self._rid}: {e}")
-            torch.cuda.empty_cache()
-            sys.exit(1)
-        # Run postprocessing
-        try:
-            self.postprocessor.run(inference, hres_ignore, rgb)
-        except Exception as e:
-            self.logger.error(f"Error postprocessing ROI {self._rid}: {e}")
-            torch.cuda.empty_cache()
-            sys.exit(1)
-
-    def set_device(self) -> None:
-        """Set device to run model on."""
-        if torch.cuda.device_count() > 4:
-            self.device = f"cuda:{self.models[self._modelname]['device']}"
-            self.logger.info(f"Running ROI {self._rid} with model {self._modelname} on device {self.device}")
-        elif torch.cuda.is_available() and (torch.cuda.device_count() < 5):
-            self.device = "cuda:0"
-        else:
-            self.device = "cpu"
-
-    def get_tile(self) -> Tile:
-        """Get tile for the current ROI."""
-        return self._slide.extract_tile(
-            coords=self._top_rois[self._rid][1],
+        self.roi.name = (
+            f"{self._sldname}_roi-{self.roi.number}"
+            f"{self._bounds2str(*self.roi.coords)}"
+        )
+        # get and predict roi
+        tile = self._slide.extract_tile(
+            coords=self._top_rois[self.roi.number][1],
             mpp=self.hres_mpp,
             tile_size=(self.roi_side_hres, self.roi_side_hres),
         )
+        self._provide_input(tile=tile)
 
-    @property
-    def logger(self):
-        return self._logger
-
-    @logger.setter
-    def logger(self, logger):
-        self._logger = logger
-
-    @property
-    def _roicoords(self):
-        return [int(j) for j in self._top_rois[self._rid][1]]
+    def _get_roi_coords(self, roi_number: int) -> list:
+        """Get the coordinates of the ROI."""
+        return [int(j) for j in self._top_rois[roi_number][1]]
 
     @staticmethod
     def _bounds2str(left, top, right, bottom):
         return f"_left-{left}_top-{top}_right-{right}_bottom-{bottom}"
 
-class RoiPreProcessor(RoiProcessor):
-    def __init__(self, parent: RoiProcessor):
-        self.parent = parent
+    def _provide_input(self, tile: Tile):
+        """Get MuTILS predictions for one ROI."""
+        hres_ignore, lres_ignore = self._get_tile_ignore(tile)
+        rgb = self._maybe_color_normalize(
+            tile.image.convert("RGB"), mask_out=hres_ignore
+        )
+        self._prep_batchdata(rgb, lres_ignore)
+        self.roi.hres_ignore = hres_ignore
+        self.roi.img = rgb
 
-    def run(self, tile: Tile) -> tuple:
-        """Run preprocessing for the ROI.
-
-        Parameters:
-        ----------
-        tile: Tile
-            Tile object containing the ROI image.
-
-        Returns:
-        -------
-        tuple
-            Tuple containing the RGB image, batch data, and high resolution ignore mask.
-        """
-        hres_ignore, lres_ignore = self.get_tile_ignore(tile)
-        rgb = self.maybe_color_normalize(tile.image.convert('RGB'), mask_out=hres_ignore)
-        batch = self.prep_batchdata(rgb, lres_ignore)
-
-        return rgb, batch, hres_ignore
-
-    def get_tile_ignore(self, tile: Tile, filter_tissue=False, get_lres=True) -> tuple:
-        """Get region outside tissue (eg. marker pen & white space)
-
-        Parameters:
-        ----------
-        tile: Tile
-            Tile object containing the ROI image.
-        filter_tissue: bool
-            Whether to filter tissue or not.
-        get_lres: bool
-            Whether to get low resolution ignore mask or not.
-
-        Returns:
-        -------
-        tuple
-            Tuple containing the high resolution and low resolution ignore masks.
-        """
+    def _get_tile_ignore(self, tile: Tile, filter_tissue=False, get_lres=True):
+        """Get region outside tissue (eg. marker pen & white space)"""
         tile._filter_tissue = filter_tissue
         hres_ignore = ~tile._tissue_mask
         hres_ignore, _ = get_objects_from_binmask(
-            hres_ignore, minpixels=128, use_watershed=False)
+            hres_ignore, minpixels=128, use_watershed=False
+        )
         hres_ignore = Image.fromarray(hres_ignore)
         if get_lres:
             lres_ignore = hres_ignore.resize(
-                (self.parent.roi_side_lres, self.parent.roi_side_lres), Image.NEAREST)
+                (self.roi_side_lres, self.roi_side_lres), Image.NEAREST
+            )
             lres_ignore = np.array(lres_ignore, dtype=bool)
         else:
             lres_ignore = None
@@ -238,90 +198,155 @@ class RoiPreProcessor(RoiProcessor):
 
         return hres_ignore, lres_ignore
 
-    def maybe_color_normalize(self, rgb: Image, mask_out=None) -> Image:
-        """Color normalize image if needed.
-
-        Parameters:
-        ----------
-        rgb: Image
-            RGB image to color normalize.
-        mask_out: np.array
-            Mask to ignore regions for color normalization.
-
-        Returns:
-        -------
-        Image
-            Color normalized image.
-        """
-        if self.parent.cnorm:
+    def _maybe_color_normalize(self, rgb: Image, mask_out=None):
+        """"""
+        if self.cnorm:
             rgb = deconvolution_based_normalization(
-                np.array(rgb), mask_out=mask_out, **self.parent.cnorm_kwargs)
+                np.array(rgb), mask_out=mask_out, **self.cnorm_kwargs
+            )
             rgb = np_to_pil(rgb)
 
         return rgb
 
-    def prep_batchdata(self, rgb: Image, lres_ignore=None) -> list:
+    def _prep_batchdata(self, rgb: Image, lres_ignore=None):
         """Prep tensor batch data for MuTILs model inference."""
-        # prep batch tensors
-        batchdata = []
-        for aug in range(self.parent.ntta + 1):
-            # maybe apply test-time augmentation
-            rgb1 = rgb.copy()
-            if aug > 0:
-                rgb1, _ = self.parent.dltransforms(rgb1, {})
-            # resize low resolution rgb to desired mpp
-            lres_rgb1 = rgb1.resize(
-                (self.parent.roi_side_lres, self.parent.roi_side_lres), Image.LANCZOS)
-            # tensorize
-            rgb1, _ = pil2tensor(rgb1, {})
-            lres_rgb1, _ = pil2tensor(lres_rgb1, {})
-            bd = {
-                'highres_rgb': rgb1[None, ...],
-                'lowres_rgb': lres_rgb1[None, ...],
-            }
-            if lres_ignore is not None:
-                ignore = torch.as_tensor(lres_ignore, dtype=torch.float32)
-                bd['lowres_ignore'] = ignore[None, None, ...]
-            batchdata.append(bd)
-        # move all to device
+
+        # Resize low resolution rgb to desired mpp
+        lres_rgb = rgb.resize((self.roi_side_lres, self.roi_side_lres), Image.LANCZOS)
+
+        # Get numpy arrays from Image objects
+        img = np.array(rgb, dtype=np.float32)
+        rgb = np.transpose(img, (2, 0, 1)) / 255.0
+
+        img = np.array(lres_rgb, dtype=np.float32)
+        lres_rgb = np.transpose(img, (2, 0, 1)) / 255.0
+
+        if lres_ignore is not None:
+            ignore = np.asarray(lres_ignore, dtype=np.float32)
+            ignore = ignore[None, None, ...]
+
+        self.roi.batch = BatchData(
+            highres_rgb=rgb[None, ...],
+            lowres_rgb=lres_rgb[None, ...],
+            lowres_ignore=ignore,
+        )
+
+
+# ==================================================================================================
+class ROIInferenceProcessor:
+    def __init__(
+        self,
+        gpu_id: int,
+        inference_queue: mp.Queue,
+        postprocess_queue: mp.Queue,
+        model: dict,
+    ):
+        self.gpu_id = gpu_id
+        self.inference_queue = inference_queue
+        self.postprocess_queue = postprocess_queue
+        self.model = model
+
+    def run(self):
+        while True:
+            roi: ROI = self.inference_queue.get()
+            if roi is None:
+                self.put(end_signal=True)
+                break
+            result = self.inference(roi)
+            roi.to_cpu()
+            self.inference_result = InferenceResult(
+                number=roi.number,
+                coords=roi.coords,
+                name=roi.name,
+                model=roi.model,
+                batch=roi.batch,
+                hres_ignore=roi.hres_ignore,
+                img=roi.img,
+                result=result,
+            )
+            self.inference_result.to_cpu()
+            torch.cuda.empty_cache()
+            self.put()
+
+    def inference(self, roi: ROI):
+
+        highres_rgb = torch.as_tensor(roi.batch.highres_rgb, dtype=torch.float32)
+        lowres_rgb = torch.as_tensor(roi.batch.lowres_rgb, dtype=torch.float32)
+        lowres_ignore = torch.as_tensor(roi.batch.lowres_ignore, dtype=torch.float32)
+
         batchdata = [
-            {k: v.to(self.parent.device) for k, v in bd.items()} for bd in batchdata
+            {
+                "highres_rgb": highres_rgb.to(f"cuda:{self.gpu_id}"),
+                "lowres_rgb": lowres_rgb.to(f"cuda:{self.gpu_id}"),
+                "lowres_ignore": lowres_ignore.to(f"cuda:{self.gpu_id}"),
+            }
         ]
-        return batchdata
 
-class RoiInferenceProcessor(RoiProcessor):
-    def __init__(self, parent: RoiProcessor):
-        self.parent = parent
+        _model = self.model["model"]
 
-    @torch.no_grad()
-    def run(self, batchdata: list) -> dict:
-        """Do MuTILs model inference.
-
-        Parameters:
-        ----------
-        batchdata: list
-            List containing the batch data.
-
-        Returns:
-        -------
-        dict
-            Dictionary containing the model inference.
-        """
-        model_info = self.parent.models[self.parent._modelname]  # Retrieve model
-        model = model_info["model"]
-
-        inference = model(batchdata)
+        with torch.no_grad():
+            inference = _model(batchdata)
 
         del batchdata
-        torch.cuda.empty_cache()
 
         return inference
 
-class RoiPostProcessor(RoiProcessor):
-    def __init__(self, parent: RoiProcessor):
-        self.parent = parent
+    def put(self, end_signal=False):
+        """Put inference result into the postprocess queue."""
+        if end_signal:
+            return
 
-    def run(self, inference: dict, hres_ignore: np.array, rgb: Image) -> None:
+        self.postprocess_queue.put(self.inference_result)
+
+        del self.inference_result
+        torch.cuda.empty_cache()
+
+
+# ==================================================================================================
+class ROIPostProcessor:
+    def __init__(self, process_number: int, postprocess_queue: mp.Queue, configs: dict):
+        self.process_number = process_number
+        self.postprocess_queue = postprocess_queue
+        self._sldname = configs.get("_sldname")
+        self._slide = configs.get("_slide")
+        self.filter_stromal_whitespace = configs.get("filter_stromal_whitespace")
+        self.min_nucl_size = configs.get("min_nucl_size")
+        self.max_nucl_size = configs.get("max_nucl_size")
+        self.no_watershed_lbls = configs.get("no_watershed_lbls")
+        self.hres_mpp = configs.get("hres_mpp")
+        self.roi_side_hres = configs.get("roi_side_hres")
+        self.discard_edge_hres = configs.get("discard_edge_hres")
+        self.n_edge_pixels_discarded = configs.get("n_edge_pixels_discarded")
+        self.max_salient_stroma_distance = configs.get("max_salient_stroma_distance")
+        self.min_tumor_for_saliency = configs.get("min_tumor_for_saliency")
+        self.maskout_region_codes = configs.get("maskout_region_codes")
+        self.nprops_kwargs = configs.get("nprops_kwargs")
+        self._savedir = configs.get("_savedir")
+        self.save_annotations = configs.get("save_annotations")
+        self.save_wsi_mask = configs.get("save_wsi_mask")
+        self.save_nuclei_meta = configs.get("save_nuclei_meta")
+        self.save_nuclei_props = configs.get("save_nuclei_props")
+        self._debug = configs.get("_debug")
+        self.rcd = model_configs.RegionCellCombination.REGION_CODES
+        self.rcc = model_configs.RegionCellCombination
+        self.ncd = model_configs.RegionCellCombination.NUCLEUS_CODES
+        self.VisConfigs = model_configs.VisConfigs
+
+    def run(self):
+        self.logger = get_configured_logger(
+            logdir="/home/output/LOGS",
+            prefix=f"MuTILsWSIRunner_chunk{self.process_number}",
+            tofile=True,
+        )
+        collect_errors.logger = self.logger
+        while True:
+            roi: InferenceResult = self.postprocess_queue.get()
+            if roi is None:
+                break
+            self.run_roi(roi)
+            self.logger.info(f"Completed ROI {roi.number} by {roi.model}.")
+
+    def run_roi(self, roi: InferenceResult) -> None:
         """Run postprocessing for the ROI.
 
         Parameters:
@@ -333,17 +358,21 @@ class RoiPostProcessor(RoiProcessor):
         rgb: Image
             RGB image of the ROI.
         """
-        preds = self.refactor_inference(inference, hres_ignore=hres_ignore)
+        self._roicoords = roi.coords
+        self._modelname = roi.model
+        self._roiname = roi.name
+        self._rid = roi.number
+
+        preds = self.refactor_inference(roi.result, hres_ignore=roi.hres_ignore)
         if preds is None:
-            self.parent.logger.info(f"ROI {self.parent._rid} has no nuclei!")
+            self.logger.info(f"ROI {self._rid} has no nuclei!")
             return
 
-        preds['sstroma'] = self.get_salient_stroma_mask(preds['combined_mask'][..., 0])
-        self._maybe_save_roi_preds(rgb=rgb, preds=preds)
+        preds["sstroma"] = self.get_salient_stroma_mask(preds["combined_mask"][..., 0])
+        self._maybe_save_roi_preds(rgb=roi.img, preds=preds)
         preds = self._simplify_roi_preds(preds)
 
         self._summarize_roi(preds)
-
 
     def refactor_inference(self, inference, hres_ignore=None):
         """
@@ -352,13 +381,12 @@ class RoiPostProcessor(RoiProcessor):
         hres_ignore = self._get_ignore_mask(hres_ignore)
 
         # region predictions
-        rpreds = logits2preds(inference['hpf_region_logits'])[0]
+        rpreds = logits2preds(inference["hpf_region_logits"])[0]
         rpreds[hres_ignore] = 0
         rpreds = self._maybe_filter_stromal_whitespace(rpreds)
 
         # nuclei raw semantic predictions and object mask
-        npred, npred_probab = logits2preds(
-            inference['hpf_nuclei'], return_probabs=True)
+        npred, npred_probab = logits2preds(inference["hpf_nuclei"], return_probabs=True)
         objmask, objcodes = self._get_nuclei_objects_mask(npred)
 
         if len(objcodes) < 1:
@@ -372,46 +400,47 @@ class RoiPostProcessor(RoiProcessor):
 
         # get nucleus-wise probabs and semantic-object mask
         classif_df, semantic_mask = self._refactor_nuclear_hpf_mask(
-            objmask=objmask, objcodes=objcodes,
-            semantic_probabs=npred_probab)
+            objmask=objmask, objcodes=objcodes, semantic_probabs=npred_probab
+        )
         semantic_mask[hres_ignore] = 0
         combined_mask = self._combine_mask(rpreds, semantic_mask)
 
         # nuclei prediction without region constraint for comparison
         _, prenpred_probab = logits2preds(
-            inference['hpf_nuclei_pre'], return_probabs=True)
+            inference["hpf_nuclei_pre"], return_probabs=True
+        )
         pre_classif_df, presemantic_mask = self._refactor_nuclear_hpf_mask(
-            objmask=objmask, objcodes=objcodes,
-            semantic_probabs=prenpred_probab)
+            objmask=objmask, objcodes=objcodes, semantic_probabs=prenpred_probab
+        )
         presemantic_mask[hres_ignore] = 0
         precombined_mask = self._combine_mask(rpreds, presemantic_mask)
 
         # concat the classification dataframes
-        pre_classif_df = pre_classif_df.drop('Identifier.ObjectCode', axis=1)
-        pre_classif_df.columns = [
-            'Unconstrained.' + j for j in pre_classif_df.columns]
+        pre_classif_df = pre_classif_df.drop("Identifier.ObjectCode", axis=1)
+        pre_classif_df.columns = ["Unconstrained." + j for j in pre_classif_df.columns]
         classif_df = concat([classif_df, pre_classif_df], axis=1)
 
         return {
-            'nobjects_mask': objmask,  # pixel is object code
-            'combined_mask': combined_mask,  # region + semantic nucl. + edges
-            'precombined_mask': precombined_mask,  # same but unconstrained
-            'classif_df': classif_df,
+            "nobjects_mask": objmask,  # pixel is object code
+            "combined_mask": combined_mask,  # region + semantic nucl. + edges
+            "precombined_mask": precombined_mask,  # same but unconstrained
+            "classif_df": classif_df,
         }
 
     def get_salient_stroma_mask(self, mask):
         """
         Salient stroma is within x um from tumor (i.e. intra-tumoral).
         """
-        stroma_mask = mask == self.parent.rcd['STROMA']
-        stroma_mask[mask == self.parent.rcd['TILS']] = True
+        stroma_mask = mask == self.rcd["STROMA"]
+        stroma_mask[mask == self.rcd["TILS"]] = True
         params = {
-            'surround_mask': stroma_mask,
-            'max_dist': self.parent.max_salient_stroma_distance,
-            'min_ref_pixels': self.parent.min_tumor_for_saliency,
+            "surround_mask": stroma_mask,
+            "max_dist": self.max_salient_stroma_distance,
+            "min_ref_pixels": self.min_tumor_for_saliency,
         }
         peri_tumoral = get_region_within_x_pixels(
-            center_mask=mask == self.parent.rcd['TUMOR'], **params)
+            center_mask=mask == self.rcd["TUMOR"], **params
+        )
 
         # # THE FOLLOWING BADLY SKEWS RESULTS!!
         # # Normal acini are commonly only predicted as "normal" at the
@@ -428,29 +457,26 @@ class RoiPostProcessor(RoiProcessor):
         Save morphologic features for nuclei in roi.
         """
         # get hematoxylin and eosin channels
-        mask_out = np.in1d(
-            preds['combined_mask'][..., 0],
-            self.parent.maskout_region_codes
-        ).reshape(preds['combined_mask'].shape[:2])
+        mask_out = np.isin(preds["combined_mask"][..., 0], self.maskout_region_codes)
         stains, _, _ = color_deconvolution_routine(
-            im_rgb=rgb, mask_out=mask_out,
-            stain_unmixing_method='macenko_pca')
+            im_rgb=rgb, mask_out=mask_out, stain_unmixing_method="macenko_pca"
+        )
         stains = 255 - stains
         # Get nuclei and cytoplasmic features
         # Identifier.ObjectCode ensures correspondence to classif. metadata
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             nprops = compute_nuclei_features(
-                im_label=preds['nobjects_mask'],
+                im_label=preds["nobjects_mask"],
                 im_nuclei=stains[..., 0],
                 im_cytoplasm=stains[..., 1],
-                **self.parent.nprops_kwargs
+                **self.nprops_kwargs,
             )
-        nprops.rename(columns={'Label': 'Identifier.ObjectCode'}, inplace=True)
+        nprops.rename(columns={"Label": "Identifier.ObjectCode"}, inplace=True)
         for attrstr, attr in [
-            ('roiname', self.parent._roiname),
-            ('slide', self.parent._sldname),
-            ('fold', self.parent._modelname)
+            ("roiname", self._roiname),
+            ("slide", self._sldname),
+            ("fold", self._modelname),
         ]:
             if attr is not None:
                 nprops.insert(0, attrstr, attr)
@@ -463,18 +489,18 @@ class RoiPostProcessor(RoiProcessor):
         """
         Whitespace within x um from stroma is just hypodense stroma.
         """
-        if not self.parent.filter_stromal_whitespace:
+        if not self.filter_stromal_whitespace:
             return mask
 
-        stroma_mask = mask == self.parent.rcd['STROMA']
-        stroma_mask[mask == self.parent.rcd['TILS']] = True
+        stroma_mask = mask == self.rcd["STROMA"]
+        stroma_mask[mask == self.rcd["TILS"]] = True
         hypodense_stroma = get_region_within_x_pixels(
             center_mask=stroma_mask,
-            surround_mask=mask == self.parent.rcd['WHITE'],
+            surround_mask=mask == self.rcd["WHITE"],
             max_dist=32,  # todo: make as param?
-            min_ref_pixels=self.parent.min_tumor_for_saliency,
+            min_ref_pixels=self.min_tumor_for_saliency,
         )
-        mask[hypodense_stroma] = self.parent.rcd['STROMA']
+        mask[hypodense_stroma] = self.rcd["STROMA"]
 
         return mask
 
@@ -484,12 +510,15 @@ class RoiPostProcessor(RoiProcessor):
         second is nuclei semantic segmentation mask, and third is nucl. edges.
         """
         tmp_msk = semantic.copy()
-        tmp_msk[tmp_msk == self.parent.ncd['BACKGROUND']] = 0
+        tmp_msk[tmp_msk == self.ncd["BACKGROUND"]] = 0
         tmp_msk = 0 + (tmp_msk > 0)
         dilated = binary_dilation(tmp_msk)
         edges = dilated - tmp_msk
-        combined = np.uint8(np.concatenate(
-            [regions[..., None], semantic[..., None], edges[..., None]], -1))
+        combined = np.uint8(
+            np.concatenate(
+                [regions[..., None], semantic[..., None], edges[..., None]], -1
+            )
+        )
 
         return combined
 
@@ -517,9 +546,11 @@ class RoiPostProcessor(RoiProcessor):
             height = maxr - minr
 
             # Check area and size thresholds
-            if (region.area < self.parent.min_nucl_size ** 2) or \
-            (width < self.parent.min_nucl_size) or \
-            (height < self.parent.min_nucl_size):
+            if (
+                (region.area < self.min_nucl_size**2)
+                or (width < self.min_nucl_size)
+                or (height < self.min_nucl_size)
+            ):
 
                 coords = region.coords  # shape (N, 2): row (y), col (x)
                 objmask[coords[:, 0], coords[:, 1]] = 0  # Zero out the object
@@ -528,8 +559,7 @@ class RoiPostProcessor(RoiProcessor):
 
         return objmask, objcodes
 
-    def _refactor_nuclear_hpf_mask(
-            self, semantic_probabs, objmask, objcodes=None):
+    def _refactor_nuclear_hpf_mask(self, semantic_probabs, objmask, objcodes=None):
         """
         Take semantic segmentation logits and an object mask. Then, use the
         object mask to aggregate pixels to get per-nucleus classif. probab.
@@ -551,23 +581,24 @@ class RoiPostProcessor(RoiProcessor):
         # improve semantic segmentation by doing majority voting so that
         # each object's class is determined by the majority of pixels.
         classif_df, objmask2 = self._aggregate_pixels_for_nucleus(
-            semprobs=semantic_probabs, objmask=objmask.copy(),
-            objcodes=objcodes)
+            semprobs=semantic_probabs, objmask=objmask.copy(), objcodes=objcodes
+        )
         # now parse improved semantic mask
         semantic_mask = np.zeros(semantic_probabs.shape[1:])
-        coln = 'Classif.StandardClass'
+        coln = "Classif.StandardClass"
         for clname in set(classif_df.loc[:, coln].values):
             obcs = classif_df.loc[
-                classif_df.loc[:, coln] == clname,
-                'Identifier.ObjectCode'].tolist()
-            relevant_objs = np.in1d(objmask2, obcs).reshape(objmask2.shape)
-            semantic_mask[relevant_objs] = self.parent.rcc.NUCLEUS_CODES[clname]
-        semantic_mask[semantic_mask == 0] = self.parent.ncd['BACKGROUND']
+                classif_df.loc[:, coln] == clname, "Identifier.ObjectCode"
+            ].tolist()
+            relevant_objs = np.isin(objmask2, obcs)
+            semantic_mask[relevant_objs] = self.rcc.NUCLEUS_CODES[clname]
+        semantic_mask[semantic_mask == 0] = self.ncd["BACKGROUND"]
 
         return classif_df, semantic_mask
 
     def _aggregate_pixels_for_nucleus(
-            self, semprobs, objmask, objcodes=None, aggsuper=True):
+        self, semprobs, objmask, objcodes=None, aggsuper=True
+    ):
         """
         Aggregates probabilities for all pixels belonging to the same
         nucleus then maybe aggregates to get superclass probab.Then argmax.
@@ -576,9 +607,9 @@ class RoiPostProcessor(RoiProcessor):
             DataFrame indexed by nucleus code in the mask containing classif.
             probability vectors and argmaxed classification
         """
-        class2supercode = self.parent.rcc.NClass2Superclass_codes
-        code2name = self.parent.rcc.RNUCLEUS_CODES
-        supercode2name = self.parent.rcc.RSUPERNUCLEUS_CODES
+        class2supercode = self.rcc.NClass2Superclass_codes
+        code2name = self.rcc.RNUCLEUS_CODES
+        supercode2name = self.rcc.RSUPERNUCLEUS_CODES
 
         if objcodes is None:
             objcodes = np.array(unique_nonzero(objmask))
@@ -618,13 +649,13 @@ class RoiPostProcessor(RoiProcessor):
             objmask[cy, cx] = obc
 
             results[obc] = {
-                'Identifier.ObjectCode': obc,
-                'Identifier.Xmin': xmin,
-                'Identifier.Ymin': ymin,
-                'Identifier.Xmax': xmax,
-                'Identifier.Ymax': ymax,
-                'Identifier.CentroidX': cx,
-                'Identifier.CentroidY': cy
+                "Identifier.ObjectCode": obc,
+                "Identifier.Xmin": xmin,
+                "Identifier.Ymin": ymin,
+                "Identifier.Xmax": xmax,
+                "Identifier.Ymax": ymax,
+                "Identifier.CentroidX": cx,
+                "Identifier.CentroidY": cy,
             }
 
         # maybe aggregate superclass probabilities
@@ -645,18 +676,28 @@ class RoiPostProcessor(RoiProcessor):
             argmaxed_superclass = np.vectorize(supercode2name.get)(argmaxed_superclass)
 
         # Convert dictionary results to a DataFrame
-        outdf = DataFrame.from_dict(results, orient='index')
+        outdf = DataFrame.from_dict(results, orient="index")
 
-        outdf['Classif.StandardClass'] = argmaxed_class_names
+        outdf["Classif.StandardClass"] = argmaxed_class_names
         if aggsuper:
-            outdf['Classif.SuperClass'] = argmaxed_superclass
+            outdf["Classif.SuperClass"] = argmaxed_superclass
 
         # Convert probability vectors to DataFrame
-        prob_df = DataFrame(probvectors, index=objcodes, columns=[f"ClassifProbab.{code2name[lbl]}" for lbl in lbls])
+        prob_df = DataFrame(
+            probvectors,
+            index=objcodes,
+            columns=[f"ClassifProbab.{code2name[lbl]}" for lbl in lbls],
+        )
 
         if aggsuper:
-            super_prob_df = DataFrame(super_probvectors, index=objcodes,
-                                        columns=[f"SuperClassifProbab.{supercode2name[slbl]}" for slbl in range(1, num_super_classes + 1)])
+            super_prob_df = DataFrame(
+                super_probvectors,
+                index=objcodes,
+                columns=[
+                    f"SuperClassifProbab.{supercode2name[slbl]}"
+                    for slbl in range(1, num_super_classes + 1)
+                ],
+            )
             outdf = concat([outdf, prob_df, super_prob_df], axis=1)
         else:
             outdf = concat([outdf, prob_df], axis=1)
@@ -674,20 +715,22 @@ class RoiPostProcessor(RoiProcessor):
         since they are commonly elongated and watershed cuts them up!
         """
         ssegmask = npred.copy()
-        ssegmask[ssegmask == self.parent.ncd['BACKGROUND']] = 0
+        ssegmask[ssegmask == self.ncd["BACKGROUND"]] = 0
         lbls = unique_nonzero(ssegmask)
         # get PRELIMINARY object mask and codes -- uses watershed
         npred_binary = ssegmask.copy()
         npred_binary = 0 + (npred_binary > 0)
         objmask, objcodes = get_objects_from_binmask(
-            binmask=npred_binary, open_first=True,
-            minpixels=self.parent.min_nucl_size ** 2,
-            maxpixels=self.parent.max_nucl_size ** 2,
-            mindist=5, use_watershed=True,
+            binmask=npred_binary,
+            open_first=True,
+            minpixels=self.min_nucl_size**2,
+            maxpixels=self.max_nucl_size**2,
+            mindist=5,
+            use_watershed=True,
         )
 
         # maybe this ROI only has watershed classes
-        no_watershed = set(lbls).intersection(self.parent.no_watershed_lbls)
+        no_watershed = set(lbls).intersection(self.no_watershed_lbls)
         if len(no_watershed) < 1:
             return objmask, objcodes.tolist()
 
@@ -696,7 +739,7 @@ class RoiPostProcessor(RoiProcessor):
 
         # This array holds the PRELIMINARY pixel count for each nucleus (rows)
         # for each class (columns) for efficiency majority voting
-        obj_labcounts = DataFrame(0., index=objcodes, columns=lbls)
+        obj_labcounts = DataFrame(0.0, index=objcodes, columns=lbls)
         for lbl in lbls:
             lblmask = 0 + (ssegmask == lbl)
             lblobjs = objmask.copy()
@@ -709,18 +752,20 @@ class RoiPostProcessor(RoiProcessor):
         obj_lbls = [lbls[idx] for idx in lbl_idxs]
         # Isolate binary mask for nuclei subset where we don't want watershed.
         watershed_objs = [
-            obc for lab, obc in zip(obj_lbls, objcodes)
-            if lab not in no_watershed]
+            obc for lab, obc in zip(obj_lbls, objcodes) if lab not in no_watershed
+        ]
         binmask_subset = npred_binary.copy()
-        ignore = np.in1d(objmask, watershed_objs).reshape(objmask.shape)
+        ignore = np.isin(objmask, watershed_objs)
         binmask_subset[ignore] = 0
         objmask[binmask_subset > 0] = 0
         # object mask for classes where we don't like watershed (fibroblasts)
         objmask2, _ = get_objects_from_binmask(
-            binmask=binmask_subset, open_first=True,
-            minpixels=self.parent.min_nucl_size ** 2,
-            maxpixels=self.parent.max_nucl_size ** 2,
-            mindist=5, use_watershed=False,
+            binmask=binmask_subset,
+            open_first=True,
+            minpixels=self.min_nucl_size**2,
+            maxpixels=self.max_nucl_size**2,
+            mindist=5,
+            use_watershed=False,
         )
         # merge the two object masks
         bck2 = objmask2 == 0
@@ -734,11 +779,13 @@ class RoiPostProcessor(RoiProcessor):
     def _get_ignore_mask(self, ignore):
         """Get hres ignore mask with discard edges."""
         if ignore is None:
-            ignore = torch.zeros(
-                (self.parent.roi_side_hres, self.parent.roi_side_hres),
-                dtype=bool, device=self.parent.device)
-        if self.parent.discard_edge_hres > 0:
-            de = self.parent.discard_edge_hres
+            # NOTE: We are off from the GPU
+            # ignore = torch.zeros(
+            #     (self.roi_side_hres, self.roi_side_hres),
+            #     dtype=bool, device=self.device)
+            ignore = np.zeros((self.roi_side_hres, self.roi_side_hres), dtype=bool)
+        if self.discard_edge_hres > 0:
+            de = self.discard_edge_hres
             ignore[:de, :] = True
             ignore[-de:, :] = True
             ignore[:, :de] = True
@@ -751,85 +798,87 @@ class RoiPostProcessor(RoiProcessor):
         """
         Save nuclei locations annotation.
         """
-        if not self.parent.save_annotations:
+        if not self.save_annotations:
             return
         # TODO: consider removing pandas dataframes from this function
         # fix coords to wsi base magnification
-        left, top, _, _ = self.parent._roicoords
+        left, top, _, _ = self._roicoords
         colmap = {
-            'Identifier.CentroidX': 'x',
-            'Identifier.CentroidY': 'y',
-            'Classif.StandardClass': 'StandardClass',
-            'Classif.SuperClass': 'SuperClass',
+            "Identifier.CentroidX": "x",
+            "Identifier.CentroidY": "y",
+            "Classif.StandardClass": "StandardClass",
+            "Classif.SuperClass": "SuperClass",
         }
         df = classif_df.loc[:, list(colmap.keys())].copy()
         df.rename(columns=colmap, inplace=True)
         # df.loc[:, ['x', 'y']] *= self.hres_mpp / self._slide.base_mpp
-        df[['x', 'y']] = df[['x', 'y']].astype(float) * (self.parent.hres_mpp / self.parent._slide.base_mpp)
-        df.loc[:, 'x'] += left
-        df.loc[:, 'y'] += top
+        df[["x", "y"]] = df[["x", "y"]].astype(float) * (
+            self.hres_mpp / self._slide.base_mpp
+        )
+        df.loc[:, "x"] += left
+        df.loc[:, "y"] += top
 
         self._save_nuclei_locs_hui_style(df)
 
     @collect_errors()
     def _maybe_save_roi_preds(self, rgb, preds):
         """Save masks, metadata, etc."""
-        if self.parent.save_wsi_mask:
-            mask = preds['combined_mask'].copy()
-            imwrite(
-                opj(self.parent._savedir, 'roiMasks', self.parent._roiname + '.png'), mask
-            )
+        if self.save_wsi_mask:
+            mask = preds["combined_mask"].copy()
+            imwrite(opj(self._savedir, "roiMasks", self._roiname + ".png"), mask)
         self._maybe_visualize_roi(
-            rgb, mask=preds['combined_mask'], sstroma=preds['sstroma'])
-        if self.parent.save_nuclei_meta:
-            preds['classif_df'].to_csv(
-                opj(self.parent._savedir, 'nucleiMeta', self.parent._roiname + '.csv'),
+            rgb, mask=preds["combined_mask"], sstroma=preds["sstroma"]
+        )
+        if self.save_nuclei_meta:
+            preds["classif_df"].to_csv(
+                opj(self._savedir, "nucleiMeta", self._roiname + ".csv"),
             )
         self._maybe_save_nuclei_props(rgb=rgb, preds=preds)
-        self._maybe_save_nuclei_annotation(preds['classif_df'])
+        self._maybe_save_nuclei_annotation(preds["classif_df"])
 
     @collect_errors()
     def _maybe_visualize_roi(self, rgb, mask, sstroma):
         """
         Plot and save roi visualization.
         """
-        if not self.parent._debug:
+        if not self._debug:
             return
 
-        _, ax = plt.subplots(1, 2, figsize=(7. * 2, 7.))
+        _, ax = plt.subplots(1, 2, figsize=(7.0 * 2, 7.0))
         ax[0].imshow(rgb)
         ax[0].imshow(
-            np.ma.masked_array(sstroma, mask=~sstroma), alpha=0.3,
+            np.ma.masked_array(sstroma, mask=~sstroma),
+            alpha=0.3,
             cmap=ListedColormap([[0.01, 0.74, 0.25]]),
         )
         ax[1].imshow(
-            gvcm(mask), cmap=self.parent.VisConfigs.COMBINED_CMAP,
-            interpolation='nearest')
+            gvcm(mask), cmap=self.VisConfigs.COMBINED_CMAP, interpolation="nearest"
+        )
         plt.tight_layout(pad=0.4)
-        plt.savefig(opj(self.parent._savedir, 'roiVis', self.parent._roiname + '.png'))
+        plt.savefig(opj(self._savedir, "roiVis", self._roiname + ".png"))
         plt.close()
 
     @collect_errors()
     def _maybe_save_nuclei_props(self, rgb, preds):
         """Get and save nuclear morphometric features."""
-        if not self.parent.save_nuclei_props:
+        if not self.save_nuclei_props:
             return
         # self.logger.info(self._rmonitor + ": getting nuclei props ..")
         props = self.get_nuclei_props_df(rgb=np.uint8(rgb), preds=preds)
         props.to_csv(
-            opj(self.parent._savedir, 'nucleiProps', self.parent._roiname + '.csv'),
+            opj(self._savedir, "nucleiProps", self._roiname + ".csv"),
         )
 
     @staticmethod
     def _simplify_roi_preds(preds):
         """Keep only what's needed and simplify terminology."""
         keep_cols = [
-            c for c in preds['classif_df'].columns
-            if not c.startswith('Unconstrained.')]
+            c for c in preds["classif_df"].columns if not c.startswith("Unconstrained.")
+        ]
         return {
-            'mask': preds['combined_mask'],
-            'sstroma': preds['sstroma'],
-            'cldf': preds['classif_df'].loc[:, keep_cols],
+            "mask": preds["combined_mask"],
+            "sstroma": preds["sstroma"],
+            "cldf": preds["classif_df"].loc[:, keep_cols],
         }
 
     def _summarize_roi(self, preds):
@@ -837,43 +886,46 @@ class RoiPostProcessor(RoiProcessor):
         Get metrics from roi.
         """
         rgsumm, metrics = self._get_region_metrics(
-            preds['mask'][..., 0], sstroma=preds['sstroma'])
+            preds["mask"][..., 0], sstroma=preds["sstroma"]
+        )
         nusumm, nmetrics = self._get_nuclei_metrics(
-            preds['cldf'], rstroma_count=rgsumm['pixelCount_AnyStroma'])
+            preds["cldf"], rstroma_count=rgsumm["pixelCount_AnyStroma"]
+        )
         metrics.update(nmetrics)
-        left, top, right, bottom = self.parent._roicoords
+        left, top, right, bottom = self._roicoords
         meta = {
-            'slide_name': self.parent._sldname,
-            'roi_id': self.parent._rid,
-            'roi_name': self.parent._roiname,
-            'wsi_left': left,
-            'wsi_top': top,
-            'wsi_right': right,
-            'wsi_bottom': bottom,
-            'mpp': self.parent.hres_mpp,
-            'model_name': self.parent._modelname,
-            'metrics': metrics,
-            'region_summary': rgsumm,
-            'nuclei_summary': nusumm,
+            "slide_name": self._sldname,
+            "roi_id": self._rid,
+            "roi_name": self._roiname,
+            "wsi_left": left,
+            "wsi_top": top,
+            "wsi_right": right,
+            "wsi_bottom": bottom,
+            "mpp": self.hres_mpp,
+            "model_name": self._modelname,
+            "metrics": metrics,
+            "region_summary": rgsumm,
+            "nuclei_summary": nusumm,
         }
-        save_json(meta, path=opj(
-            self.parent._savedir, 'roiMeta', self.parent._roiname + '.json'))
+        save_json(meta, path=opj(self._savedir, "roiMeta", self._roiname + ".json"))
 
     def _get_region_metrics(self, mask, sstroma):
         """
         Summarize region mask and some metrics.
         """
         # pixel summaries
-        out = summarize_region_mask(mask, rcd=self.parent.rcd)
-        out['pixelCount_EXCLUDE'] -= self.parent.n_edge_pixels_discarded
+        out = summarize_region_mask(mask, rcd=self.rcd)
+        out["pixelCount_EXCLUDE"] -= self.n_edge_pixels_discarded
         # isolate salient tils
-        salient_tils = mask == self.parent.rcd['TILS']
+        salient_tils = mask == self.rcd["TILS"]
         salient_tils[~sstroma] = False
-        p = 'pixelCount'
-        out.update({
-            f'{p}_SalientStroma': int(sstroma.sum()),
-            f'{p}_SalientTILs': int(salient_tils.sum()),
-        })
+        p = "pixelCount"
+        out.update(
+            {
+                f"{p}_SalientStroma": int(sstroma.sum()),
+                f"{p}_SalientTILs": int(salient_tils.sum()),
+            }
+        )
 
         return self._region_metrics(out)
 
@@ -882,28 +934,28 @@ class RoiPostProcessor(RoiProcessor):
         Given pixel count summary, summarize region metrics
         """
         # summarize metrics
-        p = 'pixelCount'
-        everything = nrois * (
-                (self.parent.roi_side_hres ** 2) - self.parent.n_edge_pixels_discarded)
-        junk = out[f'{p}_JUNK'] + out[f'{p}_WHITE'] + out[f'{p}_EXCLUDE']
+        p = "pixelCount"
+        everything = nrois * ((self.roi_side_hres**2) - self.n_edge_pixels_discarded)
+        junk = out[f"{p}_JUNK"] + out[f"{p}_WHITE"] + out[f"{p}_EXCLUDE"]
         nonjunk = everything - junk
-        anystroma = out[f'{p}_STROMA'] + out[f'{p}_TILS']
-        out[f'{p}_AnyStroma'] = anystroma
+        anystroma = out[f"{p}_STROMA"] + out[f"{p}_TILS"]
+        out[f"{p}_AnyStroma"] = anystroma
         # Saliency score is higher when there's more tumor & salient stroma
         # Note that relying on stroma within x microns from tumor edge is not
         # enough as ROIs with scattered tumor nests that are spaced out would
         # get a high score even though there's little tumor or maybe even
         # a few misclassified pixels here and there. So we use both.
-        sscore = out[f'{p}_SalientStroma'] / everything
-        sscore *= out[f'{p}_TUMOR'] / everything
+        sscore = out[f"{p}_SalientStroma"] / everything
+        sscore *= out[f"{p}_TUMOR"] / everything
         metrics = {
-            'SaliencyScore': sscore,
-            'TissueRatio': nonjunk / everything,
-            'TILs2AnyStromaRatio': _divnonan(out[f'{p}_TILS'], anystroma),
-            'TILs2AllRatio': _divnonan(out[f'{p}_TILS'], nonjunk),
-            'TILs2TumorRatio': _divnonan(out[f'{p}_TILS'], out[f'{p}_TUMOR']),
-            'SalientTILs2StromaRatio': _divnonan(
-                out[f'{p}_SalientTILs'], out[f'{p}_SalientStroma']),
+            "SaliencyScore": sscore,
+            "TissueRatio": nonjunk / everything,
+            "TILs2AnyStromaRatio": _divnonan(out[f"{p}_TILS"], anystroma),
+            "TILs2AllRatio": _divnonan(out[f"{p}_TILS"], nonjunk),
+            "TILs2TumorRatio": _divnonan(out[f"{p}_TILS"], out[f"{p}_TUMOR"]),
+            "SalientTILs2StromaRatio": _divnonan(
+                out[f"{p}_SalientTILs"], out[f"{p}_SalientStroma"]
+            ),
         }
 
         return out, metrics
@@ -913,7 +965,8 @@ class RoiPostProcessor(RoiProcessor):
         Summarize nuclei mask and some metrics.
         """
         out = summarize_nuclei_mask(
-            cldf.loc[:, 'Classif.StandardClass'].to_dict(), ncd=self.parent.ncd)
+            cldf.loc[:, "Classif.StandardClass"].to_dict(), ncd=self.ncd
+        )
 
         return self._nuclei_metrics(out, rstroma_count)
 
@@ -927,12 +980,11 @@ class RoiPostProcessor(RoiProcessor):
         stroman = out[f"{nst}_StromalCellNOS"]
         allstroma = tiln + stroman
         metrics = {
-            'nTILsCells2AnyStromaRegionArea': _divnonan(tiln, rst_count),
-            'nTILsCells2nStromaCells': _divnonan(tiln, stroman),
-            'nTILsCells2nAllStromaCells': _divnonan(tiln, allstroma),
-            'nTILsCells2nAllCells': _divnonan(tiln, out[f"{nst}_all"]),
-            'nTILsCells2nTumorCells': _divnonan(
-                tiln, out[f"{nst}_CancerEpithelium"]),
+            "nTILsCells2AnyStromaRegionArea": _divnonan(tiln, rst_count),
+            "nTILsCells2nStromaCells": _divnonan(tiln, stroman),
+            "nTILsCells2nAllStromaCells": _divnonan(tiln, allstroma),
+            "nTILsCells2nAllCells": _divnonan(tiln, out[f"{nst}_all"]),
+            "nTILsCells2nTumorCells": _divnonan(tiln, out[f"{nst}_CancerEpithelium"]),
         }
 
         return out, metrics
@@ -940,12 +992,11 @@ class RoiPostProcessor(RoiProcessor):
     def _save_nuclei_locs_hui_style(self, df):
         """Save nuclei centroids annotation HistomicsUI style."""
         anndoc = {
-            'name': f"nucleiLocs_{self.parent._roiname}",
-            'description': 'Nuclei centroids.',
-            'elements': self._df_to_points_list_hui_style(df),
+            "name": f"nucleiLocs_{self._roiname}",
+            "description": "Nuclei centroids.",
+            "elements": self._df_to_points_list_hui_style(df),
         }
-        savename = opj(
-            self.parent._savedir, 'annotations', f'nucleiLocs_{self.parent._roiname}.json')
+        savename = opj(self._savedir, "annotations", f"nucleiLocs_{self._roiname}.json")
         save_json(anndoc, path=savename)
 
     def _df_to_points_list_hui_style(self, df):
@@ -961,22 +1012,24 @@ class RoiPostProcessor(RoiProcessor):
         if df.shape[0] < 1:
             return []
 
-        df.loc[:, 'lineColor'] = df.loc[:, 'StandardClass'].map({
-            cls: self._huicolor(col)
-            for cls, col in self.parent.VisConfigs.NUCLEUS_COLORS.items()
-        })
+        df.loc[:, "lineColor"] = df.loc[:, "StandardClass"].map(
+            {
+                cls: self._huicolor(col)
+                for cls, col in self.VisConfigs.NUCLEUS_COLORS.items()
+            }
+        )
         records = (
-                "{'type': 'point', " f"'group': '"
-                + df.loc[:, 'StandardClass']
-                + "', 'label': {" f"'value': '"
-                + df.loc[:, 'StandardClass']
-                + "'}, 'lineColor': '"
-                + df.loc[:, 'lineColor']
-                + "', 'lineWidth': 2, 'center': ["
-                + df.loc[:, 'x'].astype(int).astype(str)
-                + ", "
-                + df.loc[:, 'y'].astype(int).astype(str)
-                + ", 0]}"
+            "{'type': 'point', "
+            f"'group': '" + df.loc[:, "StandardClass"] + "', 'label': {"
+            f"'value': '"
+            + df.loc[:, "StandardClass"]
+            + "'}, 'lineColor': '"
+            + df.loc[:, "lineColor"]
+            + "', 'lineWidth': 2, 'center': ["
+            + df.loc[:, "x"].astype(int).astype(str)
+            + ", "
+            + df.loc[:, "y"].astype(int).astype(str)
+            + ", 0]}"
         )
         records = records.apply(lambda x: ast.literal_eval(x)).to_list()
 

--- a/mutils_panoptic/MuTILsWSIRunner.py
+++ b/mutils_panoptic/MuTILsWSIRunner.py
@@ -184,6 +184,8 @@ class ProcessManager:
 
         Parameters
         ----------
+        process_number : int
+            The process number for logging.
         postprocess_queue : mp.Queue
             The queue for passing the inference results to the postprocessing process.
         configs : dict
@@ -461,7 +463,9 @@ class MuTILsWSIRunner:
                 "cnorm_kwargs": self.cnorm_kwargs,
             }
             preprocessor = ROIPreProcessor(
-                worker_id=0, inference_queue=[], roi_chunk=[], configs=preproc_configs
+                inference_queue=[],
+                roi_chunk=[],
+                configs=preproc_configs,
             )
             # 2. Inference =============================================================
             inference_processor = ROIInferenceProcessor(
@@ -488,7 +492,7 @@ class MuTILsWSIRunner:
                 "_debug": self._debug,
             }
             postprocessor = ROIPostProcessor(
-                worker_id=0, postprocess_queue=[], configs=postproc_configs
+                process_number=0, postprocess_queue=[], configs=postproc_configs
             )
 
             for i, roi in enumerate(rois):


### PR DESCRIPTION
The pull request has the following changes:

1. The configuration file and the configuration forwarding has been refactored for MuTILsWSIRunner. A `Config` dataclass has been created in `configs/MuTILsWSIRunConfigs.py` with default values set here instead of in the constructor of `MuTILsWSIRunner`. The content of `MuTILsWSIRunConfigs.yaml` has been reduced, it serves only for overwriting default configuration setting but can left empty too. The constructor of `MuTILsWSIRunner` has been rewritten according to the new configuration dataclass.

2. The MuTILs ROI processing pipeline has had a major refactor:
    - The `run_all_slides` method has been removed from  `MuTILsWSIRunner` class. The loop over the slides has been moved to the main guard. `MuTILsWSIRunner` processes one slide at a time.
    - The `run_slide` method is the new entry point of `MuTILsWSIRunner`.
    - If at least 5 GPU-s are available, the `run_parallel_models` method is called which initializes queues and the process manager for isolated multiprocessing of the three ROI processing units of MuTILs: (i) preprocessing; (ii) inference; and (iii) postprocessing.
    - The new `ProcessManager` class encapsulates the handling of the separate processes and the IPC using queues. It has three `start_ ` methods, one for each processing unit. These methods are responsible for starting the multiprocessing processes. The `join_all` method joins the processes when all finished.
    - The codes of preprocessing, inference, and postprocessing have been organized in three classes: ROIPreProcessor; ROIInferenceProcessor; and ROIPostProcessor in MuTILsInference.py.
    - The inference has 5 workers which manage the data to and from 5 GPU-s. The number of the preprocessing and postprocessing workers can be adjusted according to the workload. The preprocessing is fast, while the postprocessing is slow for which the default number of workers can be 10 and 40, respectively.